### PR TITLE
upgrade to 0.16.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,11 @@ RUN apt-get update
 
 RUN apt-get -y install curl
 
-RUN curl -OL https://bitcoin.org/bin/bitcoin-core-0.16.0/bitcoin-0.16.0-x86_64-linux-gnu.tar.gz
+RUN curl -OL https://bitcoin.org/bin/bitcoin-core-0.16.3/bitcoin-0.16.3-x86_64-linux-gnu.tar.gz
 
-RUN tar zxvf bitcoin-0.16.0-x86_64-linux-gnu.tar.gz
+RUN tar zxvf bitcoin-0.16.3-x86_64-linux-gnu.tar.gz
 
-RUN ln -s /bitcoin-0.16.0/bin/bitcoin-cli /bitcoin-cli
+RUN ln -s /bitcoin-0.16.3/bin/bitcoin-cli /bitcoin-cli
 
 COPY bitcoin.conf /root/.bitcoin/bitcoin.conf
 
@@ -17,4 +17,4 @@ EXPOSE 18444/tcp
 # p2p
 EXPOSE 18443/tcp
 
-ENTRYPOINT ["/bitcoin-0.16.0/bin/bitcoind", "-regtest",  "-printtoconsole"]
+ENTRYPOINT ["/bitcoin-0.16.3/bin/bitcoind", "-regtest",  "-printtoconsole"]


### PR DESCRIPTION
Because of CVE-2018-17144，0.16.0 is no longer officially available. so upgrade to 0.16.3