### PR TITLE
Update bitcoind to 0.17.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,11 +4,11 @@ RUN apt-get update
 
 RUN apt-get -y install curl
 
-RUN curl -OL https://bitcoin.org/bin/bitcoin-core-0.16.0/bitcoin-0.16.0-x86_64-linux-gnu.tar.gz
+RUN curl -OL https://bitcoin.org/bin/bitcoin-core-0.17.1/bitcoin-0.17.1-x86_64-linux-gnu.tar.gz
 
-RUN tar zxvf bitcoin-0.16.0-x86_64-linux-gnu.tar.gz
+RUN tar zxvf bitcoin-0.17.1-x86_64-linux-gnu.tar.gz
 
-RUN ln -s /bitcoin-0.16.0/bin/bitcoin-cli /bitcoin-cli
+RUN ln -s /bitcoin-0.17.1/bin/bitcoin-cli /bitcoin-cli
 
 COPY bitcoin.conf /root/.bitcoin/bitcoin.conf
 
@@ -17,4 +17,4 @@ EXPOSE 18444/tcp
 # p2p
 EXPOSE 18443/tcp
 
-ENTRYPOINT ["/bitcoin-0.16.0/bin/bitcoind", "-regtest",  "-printtoconsole"]
+ENTRYPOINT ["/bitcoin-0.17.1/bin/bitcoind", "-regtest",  "-printtoconsole"]


### PR DESCRIPTION
Version 0.16.0 is not available any more. Update to the newest version.

Please note that several API calls you may make to these wallets have changed.
https://github.com/bitcoin/bitcoin/blob/master/doc/release-notes/release-notes-0.17.0.md